### PR TITLE
COMTF2-12 ubuntu updated to lunar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - Ubuntu update
+
+Ubuntu image version updated to lunar.
+Mono-complete replaced with mono-runtime.
+
 ## [1.0.0] - init
 
 First official version :)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM ubuntu:impish
+FROM ubuntu:lunar
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && \
     apt-get install -y --no-install-recommends gnupg ca-certificates && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
     echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" | tee /etc/apt/sources.list.d/mono-official-stable.list && \
     apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends nuget nodejs npm mono-complete mono-devel msbuild && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends nuget nodejs npm mono-runtime mono-devel msbuild && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitbucketbuildcontainer",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Inforit Bitbucket legacy build docker",
   "main": "Dockerfile",
   "scripts": {


### PR DESCRIPTION
## Purpose

The ubuntu impish version is no longer supported, so it need to be updated to the latest (lunar) version.
The resulting image size also needed to be decreased, so only the necessary mono components are included instead of mono-complete.

### Issue(s) this solves:

-[COMTF2-12](https://inforit.atlassian.net/browse/COMTF2-12)

## Approach

The original image with impish ubuntu was no longer buildable due to the lack of the Release file. I updated it to the latest version. Afterwards I modified reduced and added the mono components in a trial and error fashion until the legacy software was buildable within the container.