### PR TITLE
COMTF2-12 Ubuntu update and multistage docker build

### DIFF
--- a/Build.sh
+++ b/Build.sh
@@ -5,7 +5,6 @@ set -e
 shopt -s nullglob
 
 ROOTDIRECTORY="/source"
-PROJECTDIRECTORY=Inforit.*.Web
 
 # go to the workdir
 if [ -n "$BITBUCKET_CLONE_DIR" ]
@@ -34,7 +33,7 @@ nuget restore
 msbuild *.sln
 
 echo "Moving .NET artifact to output"
-cd $PROJECTDIRECTORY
+cd Inforit.*.Web
 mv bin /output/
 
 echo "Moving .NET configurations to output"

--- a/Build.sh
+++ b/Build.sh
@@ -37,10 +37,10 @@ cd Inforit.*.Web
 mv bin /output/
 
 echo "Moving .NET configurations to output"
-mv NLog.default.config /output/NLog.config
-mv appsettings.default.config /output/appsettings.config
-mv Web.config /output/
-mv connectionstrings.default.config /output/connectionstrings.config
+cp NLog.config /output/NLog.config
+cp appsettings.config /output/appsettings.config
+cp Web.config /output/
+cp connectionstrings.config /output/connectionstrings.config
 
 # build and copy the front-end artifact
 cd "$ROOTDIRECTORY"/client

--- a/Build.sh
+++ b/Build.sh
@@ -7,7 +7,7 @@ set -e
 shopt -s nullglob
 
 ROOTDIRECTORY="/source"
-BINDIRECTORY="${BINDIRECTORY:-"/source/server/Inforit.*.Web/bin"}"
+PROJECTDIRECTORY=Inforit.*.Web
 
 # go to the workdir
 if [ -n "$BITBUCKET_CLONE_DIR" ]
@@ -31,19 +31,26 @@ fi
 cd server
 
 
+echo "Building .NET solution"
 nuget restore
 msbuild *.sln
-mv $BINDIRECTORY /output/
-cd $BINDIRECTORY
-cd ..
-mv Nlog.config /output/
-mv appsettings.config /output/
-mv Web.config /output/
-mv connectionstrings.config /output/
 
-# build and copy the front-end artefact
+echo "Moving .NET artifact to output"
+cd $PROJECTDIRECTORY
+mv bin /output/
+
+echo "Moving .NET configurations to output"
+mv NLog.default.config /output/NLog.config
+mv appsettings.default.config /output/appsettings.config
+mv Web.config /output/
+mv connectionstrings.default.config /output/connectionstrings.config
+
+# build and copy the front-end artifact
 cd "$ROOTDIRECTORY"/client
+echo "Building node.js"
 npm install
 npm run build --if-present
 npm run test --if-present
+
+echo "Moving node.js artifact to output"
 mv ./dist /output/client

--- a/Build.sh
+++ b/Build.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # return failing exit code if any command fails
 set -e
 
@@ -47,10 +45,16 @@ mv connectionstrings.default.config /output/connectionstrings.config
 
 # build and copy the front-end artifact
 cd "$ROOTDIRECTORY"/client
-echo "Building node.js"
+echo "Building the front-end artifact"
+
+# nodejs is managed via nvm, it must be started to use nodejs commands
+. ~/.nvm/nvm.sh
+source ~/.bashrc
+nvm use ${NODEVERSION} 
+
 npm install
 npm run build --if-present
 npm run test --if-present
 
-echo "Moving node.js artifact to output"
+echo "Moving the front-end artifact to output"
 mv ./dist /output/client

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.0] - Ubuntu update
+## [2.0.0] - Ubuntu update
 
-Ubuntu image version updated to lunar.
+Ubuntu image version updated to kinetic.
 Mono-complete replaced with mono-runtime.
+Dockerfile changed to multistage build.
+Nodejs is installed and managed with nvm.
+globalquotebuild stage for global-quote builds.
+defaultbuild stage for building the rest of TF2 application.
+Build.sh config copying fixed.
+Build.sh artifact copying fixed.
+Build.sh selects and starts appropriate nodejs.
 
 ## [1.0.0] - init
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - Ubuntu update
+
+Ubuntu image version updated to lunar.
+Mono-complete replaced with mono-runtime.
+
 ## [1.0.0] - init
 
 First official version :)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM ubuntu:impish
+FROM ubuntu:lunar
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && \
     apt-get install -y --no-install-recommends gnupg ca-certificates && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
     echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" | tee /etc/apt/sources.list.d/mono-official-stable.list && \
     apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends nuget nodejs npm mono-complete mono-devel msbuild && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends nuget nodejs npm mono-runtime mono-devel msbuild && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
-FROM ubuntu:lunar
+FROM ubuntu:lunar AS base
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && \
     apt-get install -y --no-install-recommends gnupg ca-certificates && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
     echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" | tee /etc/apt/sources.list.d/mono-official-stable.list && \
     apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends nuget nodejs npm mono-runtime mono-devel msbuild && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends nuget mono-runtime mono-devel msbuild && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+FROM base as build
 RUN mkdir -p /source
 RUN mkdir -p /output
 WORKDIR /source

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN touch ~/.bashrc && chmod +x ~/.bashrc
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
 
 # customize build environment, add build script
-FROM base as dotnetbuild
+# build this stage to have base image for GQ build
+FROM base as monobuild
 RUN mkdir -p /source
 RUN mkdir -p /output
 WORKDIR /source
@@ -21,12 +22,7 @@ COPY NuGet.Config /root/.nuget/NuGet/NuGet.Config
 COPY Build.sh /Build.sh
 CMD ["/bin/bash", "/Build.sh"]
 
-# build this stage for global quote
-FROM dotnetbuild as globalquotebuild
-ENV NODEVERSION=14.16.1
-RUN . ~/.nvm/nvm.sh && source ~/.bashrc && nvm install ${NODEVERSION} 
-
 # build this stage for the rest of TF2 apps
-FROM dotnetbuild as defaultbuild
+FROM monobuild as defaultbuild
 ENV NODEVERSION=19.8.1
 RUN . ~/.nvm/nvm.sh && source ~/.bashrc && nvm install ${NODEVERSION} 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,32 @@
-FROM ubuntu:lunar AS base
+# install build tools
+FROM ubuntu:kinetic AS base
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && \
     apt-get install -y --no-install-recommends gnupg ca-certificates && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
     echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" | tee /etc/apt/sources.list.d/mono-official-stable.list && \
     apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends nuget mono-runtime mono-devel msbuild && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends nuget mono-runtime mono-devel msbuild curl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+RUN touch ~/.bashrc && chmod +x ~/.bashrc
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
 
-FROM base as build
+# customize build environment, add build script
+FROM base as dotnetbuild
 RUN mkdir -p /source
 RUN mkdir -p /output
 WORKDIR /source
 COPY NuGet.Config /root/.nuget/NuGet/NuGet.Config
 COPY Build.sh /Build.sh
 CMD ["/bin/bash", "/Build.sh"]
+
+# build this stage for global quote
+FROM dotnetbuild as globalquotebuild
+ENV NODEVERSION=14.16.1
+RUN . ~/.nvm/nvm.sh && source ~/.bashrc && nvm install ${NODEVERSION} 
+
+# build this stage for the rest of TF2 apps
+FROM dotnetbuild as defaultbuild
+ENV NODEVERSION=19.8.1
+RUN . ~/.nvm/nvm.sh && source ~/.bashrc && nvm install ${NODEVERSION} 

--- a/GlobalQuote/Dockerfile
+++ b/GlobalQuote/Dockerfile
@@ -1,0 +1,4 @@
+# build this stage for global quote
+FROM monobuild AS globalquotebuild
+ENV NODEVERSION=14.16.1
+RUN . ~/.nvm/nvm.sh && source ~/.bashrc && nvm install ${NODEVERSION} 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitbucketbuildcontainer",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Inforit Bitbucket legacy build docker",
   "main": "Dockerfile",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitbucketbuildcontainer",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Inforit Bitbucket legacy build docker",
   "main": "Dockerfile",
   "scripts": {


### PR DESCRIPTION
## Purpose

The ubuntu impish version is no longer supported, so it need to be updated to the latest stable (kinetic) version.

The resulting image size also needed to be decreased, so only the necessary mono components are included instead of mono-complete.

Since different projects require different nodejs version to build succesfully multiple layers are introduced to support node versions independently of each-other. Nvm is introduced to manage node versions.

Fixes are introduced to copy config files and build artifacts during the build process.

## Approach

The original image with impish ubuntu was no longer buildable due to the lack of the Release file. I updated it to the latest version. Afterwards I modified reduced and added the mono components in a trial and error fashion until the legacy software was buildable within the container.

I researched and configured nvm to run within a containerized ubuntu environment and used it to install different versions of nodejs in different docker build stages.

## PR checklist

[x] - versions incremented in .csproj and package.json  
[x] - Updated CHANGELOG  